### PR TITLE
Fix typo in equation env

### DIFF
--- a/math.tex
+++ b/math.tex
@@ -88,7 +88,7 @@ y
 
 \exercises{}
 \begin{itemize}
-\item Number equations for later reference with the \texttt{equaiton} environment.
+\item Number equations for later reference with the \texttt{equation} environment.
 \item Automatically size parenthesis and braces to fit their contents
     with \verb|\left| and \verb|\right|.
 \item Learn some of the many helpful features of the \texttt{amsmath}


### PR DESCRIPTION
As per #4, the reference to `equation` was spelt `equaiton.